### PR TITLE
Removed implied contradtion.

### DIFF
--- a/Basics/if.go
+++ b/Basics/if.go
@@ -13,8 +13,9 @@ func max(x, y int) int {
 func more(x, y int) bool {
 	if x > y {
 		return true
+	} else {
+		return false
 	}
-	return false
 }
 
 // If with precondition.


### PR DESCRIPTION
This is mostly a test of using github as a collaboration tool. 
Relying on the control-flow behavior of return and omitting the else is depending on the contradiction of return.  If a student submitted this, they would get marked down.  From the axiomatic proof, we have this in the original code:
<< T >>
if x>y {
  << x>y >>
  return x
  << ⊥ >>
}
<< ⊥ ∧ x <= y >>
return y
}

Notice that the second return has false-or-x<=y as its precondition.  Since return statements' post condition is false, they are logical contradictions.  Basically, you've written a proof by contradiction for what is otherwise a constructive proof.  

The edit is << T >>
  if x>y {
    << x>y >>
    return x
    << ⊥ >>
  } else {
    << x <= y >>
    return y
    << ⊥ >>
  }
  << ⊥ >>
}

Not only is the corresponding proof cleaner, it also uses the control structures of the language to help the reader understand that either return x or return y will be called.  The syntax givens them the logic rather than the dynamic behavior of the code.  